### PR TITLE
Introduce static translations via context locale, created Posts page

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -8,8 +8,10 @@ import {
 } from "@chakra-ui/react";
 import Link from "components/Link";
 import { FiGithub } from "react-icons/fi";
+import useTranslation from "hooks/useTranslation";
 
 export default function Footer() {
+  const { t } = useTranslation();
   const { colorMode } = useColorMode();
   return (
     <Box
@@ -28,7 +30,7 @@ export default function Footer() {
             color: "gray.600",
           }}
         >
-          <Text mr={1}>A template by</Text>
+          <Text mr={1}>{t("footer")}</Text>
           <Link
             sx={{ display: "inline-flex", alignItems: "center" }}
             href="https://github.com/g-thinh/firebase-ssr"

--- a/src/components/FormCreateAccount.tsx
+++ b/src/components/FormCreateAccount.tsx
@@ -7,12 +7,14 @@ import {
   Input,
 } from "@chakra-ui/react";
 import { createUserWithEmailAndPassword } from "firebase/auth";
+import useTranslation from "hooks/useTranslation";
 import Router from "next/router";
 import { useForm } from "react-hook-form";
 import { firebaseAuth } from "services/firebase";
 import * as Api from "types/api";
 
 export default function FormCreateAccount() {
+  const { t } = useTranslation();
   const {
     handleSubmit,
     register,
@@ -34,12 +36,12 @@ export default function FormCreateAccount() {
   return (
     <Box as="form" onSubmit={handleSubmit(createUser)}>
       <FormControl isInvalid={!!errors.email} mb={4}>
-        <FormLabel>Email address</FormLabel>
+        <FormLabel>{t("email")}</FormLabel>
         <Input
           id="email"
           type="email"
           {...register("email", {
-            required: "This is required",
+            required: t("requiredField"),
           })}
         />
         <FormErrorMessage>
@@ -47,12 +49,12 @@ export default function FormCreateAccount() {
         </FormErrorMessage>
       </FormControl>
       <FormControl isInvalid={!!errors.password}>
-        <FormLabel>Password</FormLabel>
+        <FormLabel>{t("password")}</FormLabel>
         <Input
           id="password"
           type="password"
           {...register("password", {
-            required: "This is required",
+            required: t("requiredField"),
           })}
         />
         <FormErrorMessage>
@@ -60,7 +62,7 @@ export default function FormCreateAccount() {
         </FormErrorMessage>
       </FormControl>
       <Button mt={4} colorScheme="teal" isLoading={isSubmitting} type="submit">
-        Create Account
+        {t("createAccount")}
       </Button>
     </Box>
   );

--- a/src/components/FormLogin.tsx
+++ b/src/components/FormLogin.tsx
@@ -24,7 +24,7 @@ export default function FormLogin() {
 
   async function signUserIn({ email, password }: Api.UserForm) {
     return signInWithEmailAndPassword(firebaseAuth, email, password)
-      .then(() => Router.push("/authenticated"))
+      .then(() => Router.push("/profile"))
       .catch((error) =>
         setError("email", {
           type: "manual",

--- a/src/components/FormLogin.tsx
+++ b/src/components/FormLogin.tsx
@@ -7,12 +7,14 @@ import {
   Input,
 } from "@chakra-ui/react";
 import { signInWithEmailAndPassword } from "firebase/auth";
+import useTranslation from "hooks/useTranslation";
 import Router from "next/router";
 import { useForm } from "react-hook-form";
 import { firebaseAuth } from "services/firebase";
 import * as Api from "types/api";
 
 export default function FormLogin() {
+  const { t } = useTranslation();
   const {
     handleSubmit,
     register,
@@ -34,13 +36,13 @@ export default function FormLogin() {
   return (
     <Box as="form" onSubmit={handleSubmit(signUserIn)}>
       <FormControl isInvalid={!!errors.email} mb={4}>
-        <FormLabel>Email address</FormLabel>
+        <FormLabel>{t("email")}</FormLabel>
         <Input
           autoFocus
           id="email"
           type="email"
           {...register("email", {
-            required: "This is required",
+            required: t("requiredField"),
           })}
         />
         <FormErrorMessage>
@@ -48,12 +50,12 @@ export default function FormLogin() {
         </FormErrorMessage>
       </FormControl>
       <FormControl isInvalid={!!errors.password}>
-        <FormLabel>Password</FormLabel>
+        <FormLabel>{t("password")}</FormLabel>
         <Input
           id="password"
           type="password"
           {...register("password", {
-            required: "This is required",
+            required: t("requiredField"),
           })}
         />
         <FormErrorMessage>
@@ -61,7 +63,7 @@ export default function FormLogin() {
         </FormErrorMessage>
       </FormControl>
       <Button mt={4} colorScheme="teal" isLoading={isSubmitting} type="submit">
-        Login
+        {t("login")}
       </Button>
     </Box>
   );

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -1,8 +1,10 @@
-import { Flex } from "@chakra-ui/react";
+import { Flex, Box, useBreakpoint } from "@chakra-ui/react";
 import Nav from "components/Nav";
 import Footer from "components/Footer";
+import isDev from "utils/isDev";
 
 export default function Layout({ children }: React.PropsWithChildren<{}>) {
+  const currentBreakpoint = useBreakpoint();
   return (
     <Flex
       sx={{
@@ -22,6 +24,16 @@ export default function Layout({ children }: React.PropsWithChildren<{}>) {
         {children}
       </Flex>
       <Footer />
+      {isDev() && (
+        <Box
+          px={2}
+          bg="black"
+          color="white"
+          sx={{ position: "fixed", right: "0.5rem", bottom: "0.5rem" }}
+        >
+          {currentBreakpoint}
+        </Box>
+      )}
     </Flex>
   );
 }

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -32,22 +32,44 @@ export default function Nav() {
   };
 
   return (
-    <Container maxW="100%" px={4} py={2}>
-      <Flex sx={{ justifyContent: "space-between" }}>
-        <Link
-          fontSize={[32, 36]}
-          fontWeight="bold"
-          href="/"
-          sx={{
-            ":hover": {
-              textDecoration: "none",
-              color: "teal.500",
-            },
-          }}
+    <Container maxW="100%" px={4} py={2} width="100%">
+      <Flex justifyContent="space-between">
+        <Flex
+          flexDir={{ sm: "column", md: "row" }}
+          width={{ sm: "100%", md: "auto" }}
         >
-          Simple Hub.
-        </Link>
+          <Link
+            fontSize={[32, 36]}
+            fontWeight="bold"
+            mr={{ sm: 0, md: "64px" }}
+            textAlign={{ sm: "center" }}
+            href="/"
+            sx={{
+              ":hover": {
+                textDecoration: "none",
+                color: "teal.500",
+              },
+            }}
+          >
+            Simple Hub.
+          </Link>
+          <Grid
+            fontSize="2xl"
+            fontWeight="bold"
+            mt={{ sm: 3, md: 2 }}
+            sx={{
+              gridAutoFlow: "column",
+              gap: 24,
+              alignItems: "center",
+              justifyContent: "center",
+            }}
+          >
+            <Link href="/posts">{t("posts")}</Link>
+            <Link href="/about">{t("about")}</Link>
+          </Grid>
+        </Flex>
         <Grid
+          display={{ sm: "none", md: "grid" }}
           sx={{
             gridAutoFlow: "column",
             gap: 16,
@@ -72,7 +94,7 @@ export default function Nav() {
           />
           {user ? (
             <>
-              <Link as={Button} href="/authenticated">
+              <Link as={Button} href="/profile">
                 {t("profile")}
               </Link>
               <Button colorScheme="teal" onClick={signUserOut}>

--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -3,16 +3,16 @@ import {
   Container,
   Flex,
   Grid,
-  HStack,
   IconButton,
-  useColorMode,
   Select,
+  useColorMode,
 } from "@chakra-ui/react";
 import Link from "components/Link";
 import { useAuth } from "contexts/AuthContext";
+import useTranslation from "hooks/useTranslation";
+import { useRouter } from "next/router";
 import { FiMoon, FiSun } from "react-icons/fi";
 import { signUserOut } from "utils/firebaseHelpers";
-import { useRouter } from "next/router";
 
 const languages = {
   en: "English",
@@ -23,11 +23,11 @@ export default function Nav() {
   const { colorMode, toggleColorMode } = useColorMode();
   const { user } = useAuth();
   const router = useRouter();
+  const { t } = useTranslation();
   const { pathname, asPath, query, locale, locales } = router;
 
   const handleLocaleChange = (e: React.FormEvent<HTMLSelectElement>) => {
     const newLocale = e.currentTarget.value;
-    console.log("switching to", newLocale);
     router.push({ pathname, query }, asPath, { locale: newLocale });
   };
 
@@ -54,42 +54,36 @@ export default function Nav() {
             alignItems: "center",
           }}
         >
-          <HStack spacing="16px">
-            <Select defaultValue={locale} onChange={handleLocaleChange}>
-              {locales.map((language, index) => {
-                return (
-                  <option key={index} value={language}>
-                    {languages[language]}
-                  </option>
-                );
-              })}
-            </Select>
-            <IconButton
-              aria-label="toggle dark/light mode"
-              icon={
-                colorMode === "light" ? (
-                  <FiSun size={18} />
-                ) : (
-                  <FiMoon size={18} />
-                )
-              }
-              onClick={toggleColorMode}
-            />
-            {user ? (
-              <>
-                <Link as={Button} href="/authenticated">
-                  Profile
-                </Link>
-                <Button colorScheme="teal" onClick={signUserOut}>
-                  Log out
-                </Button>
-              </>
-            ) : (
-              <Link as={Button} href="/login">
-                Login
+          <Select defaultValue={locale} onChange={handleLocaleChange}>
+            {locales.map((language, index) => {
+              return (
+                <option key={index} value={language}>
+                  {languages[language]}
+                </option>
+              );
+            })}
+          </Select>
+          <IconButton
+            aria-label="toggle dark/light mode"
+            icon={
+              colorMode === "light" ? <FiSun size={18} /> : <FiMoon size={18} />
+            }
+            onClick={toggleColorMode}
+          />
+          {user ? (
+            <>
+              <Link as={Button} href="/authenticated">
+                {t("profile")}
               </Link>
-            )}
-          </HStack>
+              <Button colorScheme="teal" onClick={signUserOut}>
+                {t("logout")}
+              </Button>
+            </>
+          ) : (
+            <Link as={Button} href="/login">
+              {t("login")}
+            </Link>
+          )}
         </Grid>
       </Flex>
     </Container>

--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -1,0 +1,43 @@
+import { useRouter } from "next/router";
+
+type DefaultLanguageResource = typeof en;
+type LanguageKey = keyof typeof en;
+
+const en = {
+  login: "Login",
+  loginPage: "Login Page",
+  logout: "Logout",
+  profile: "Profile",
+  email: "Email address",
+  password: "Password",
+  createAccount: "Create account",
+  requiredField: "This field is required",
+  footer: "Made with 💙 by",
+};
+
+const fr: DefaultLanguageResource = {
+  login: "Connexion",
+  loginPage: "Page de Connexion",
+  logout: "Déconnexion",
+  profile: "Profil",
+  email: "Addresse courriel",
+  password: "Mot de passe",
+  createAccount: "Créer un compte",
+  requiredField: "Ce champs est obligatoire",
+  footer: "Fait avec amour 💙 par",
+};
+
+const resources = {
+  en,
+  fr,
+} as const;
+
+export default function useTranslation() {
+  const { locales, locale } = useRouter();
+
+  function t(key: LanguageKey) {
+    return resources[locale][key];
+  }
+
+  return { t, locales, locale };
+}

--- a/src/hooks/useTranslation.tsx
+++ b/src/hooks/useTranslation.tsx
@@ -13,6 +13,9 @@ const en = {
   createAccount: "Create account",
   requiredField: "This field is required",
   footer: "Made with 💙 by",
+  about: "About Us",
+  posts: "Posts",
+  welcome: "Welcome",
 };
 
 const fr: DefaultLanguageResource = {
@@ -25,6 +28,9 @@ const fr: DefaultLanguageResource = {
   createAccount: "Créer un compte",
   requiredField: "Ce champs est obligatoire",
   footer: "Fait avec amour 💙 par",
+  about: "Découvrez-nous",
+  posts: "Nos articles",
+  welcome: "Bienvenue",
 };
 
 const resources = {

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -2,7 +2,7 @@ import { Box, Container, Heading } from "@chakra-ui/react";
 import RenderRichText from "components/RenderRichText";
 import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { useStoryblok } from "services/storyblok";
-import { getPaths, getStory } from "utils/apiHelpers";
+import { getStory } from "utils/apiHelpers";
 
 export async function getStaticProps(context: GetStaticPropsContext) {
   const story = await getStory("home", {
@@ -21,9 +21,8 @@ export async function getStaticProps(context: GetStaticPropsContext) {
 }
 
 export async function getStaticPaths() {
-  const paths = await getPaths();
   return {
-    paths: paths,
+    paths: [],
     fallback: "blocking",
   };
 }
@@ -31,7 +30,7 @@ export async function getStaticPaths() {
 export default function HomePage(
   props: InferGetStaticPropsType<typeof getStaticProps>
 ) {
-  const story = useStoryblok(props.story, props.preview, props.locale);
+  const story = useStoryblok(props.story);
   return (
     <Container maxW="100%">
       <Container m="auto" maxW="72rem" p={0}>

--- a/src/pages/[[...slug]].tsx
+++ b/src/pages/[[...slug]].tsx
@@ -1,4 +1,4 @@
-import { Box, Container, Heading, useColorMode } from "@chakra-ui/react";
+import { Box, Container, Heading } from "@chakra-ui/react";
 import RenderRichText from "components/RenderRichText";
 import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
 import { useStoryblok } from "services/storyblok";
@@ -32,22 +32,16 @@ export default function HomePage(
   props: InferGetStaticPropsType<typeof getStaticProps>
 ) {
   const story = useStoryblok(props.story, props.preview, props.locale);
-  const { colorMode } = useColorMode();
   return (
     <Container maxW="100%">
-      <Container m="auto" maxW="72rem">
+      <Container m="auto" maxW="72rem" p={0}>
         <Heading as="h1" mb={6} textAlign="center">
           {story.content.title}
         </Heading>
         <Heading as="h2" mb={6} textAlign="center">
           {props.locale}
         </Heading>
-        <Container
-          bg={colorMode === "dark" ? "gray.700" : "gray.200"}
-          p={4}
-          borderRadius={12}
-          boxShadow="md"
-        >
+        <Container maxW="64rem">
           <Box>{RenderRichText(story.content.body)}</Box>
         </Container>
       </Container>

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -1,0 +1,41 @@
+import { Box, Container, Heading } from "@chakra-ui/react";
+import RenderRichText from "components/RenderRichText";
+import useTranslation from "hooks/useTranslation";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
+import { useStoryblok } from "services/storyblok";
+import { getStory } from "utils/apiHelpers";
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+  const story = await getStory("about", {
+    version: context.preview ? "draft" : "published",
+    language: context.locale,
+  });
+
+  return {
+    props: {
+      story: story,
+      preview: context.preview || false,
+      locale: context.locale,
+    },
+    revalidate: 60 * 60,
+  };
+}
+
+export default function AboutPage(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
+  const story = useStoryblok(props.story, props.preview, props.locale);
+  const { t } = useTranslation();
+  return (
+    <Container>
+      <Container m="auto">
+        <Heading as="h1" mb={6} textAlign="center">
+          {t("about")}
+        </Heading>
+        <Container p={4}>
+          <Box>{RenderRichText(story.content.body)}</Box>
+        </Container>
+      </Container>
+    </Container>
+  );
+}

--- a/src/pages/about.tsx
+++ b/src/pages/about.tsx
@@ -24,7 +24,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
 export default function AboutPage(
   props: InferGetStaticPropsType<typeof getStaticProps>
 ) {
-  const story = useStoryblok(props.story, props.preview, props.locale);
+  const story = useStoryblok(props.story);
   const { t } = useTranslation();
   return (
     <Container>

--- a/src/pages/login.tsx
+++ b/src/pages/login.tsx
@@ -9,13 +9,15 @@ import {
 } from "@chakra-ui/react";
 import FormCreateAccount from "components/FormCreateAccount";
 import FormLogin from "components/FormLogin";
+import useTranslation from "hooks/useTranslation";
 
 export default function Home() {
+  const { t } = useTranslation();
   return (
     <Container>
       <Container m="auto">
         <Heading as="h1" mb={6} textAlign="center">
-          Login Page
+          {t("loginPage")}
         </Heading>
         <Tabs
           isFitted
@@ -29,8 +31,8 @@ export default function Home() {
           }}
         >
           <TabList>
-            <Tab>Login</Tab>
-            <Tab>Create an Account</Tab>
+            <Tab>{t("login")}</Tab>
+            <Tab>{t("createAccount")}</Tab>
           </TabList>
           <TabPanels>
             <TabPanel>

--- a/src/pages/posts/[...slug].tsx
+++ b/src/pages/posts/[...slug].tsx
@@ -1,8 +1,12 @@
 import { Box, Container, Heading } from "@chakra-ui/react";
 import RenderRichText from "components/RenderRichText";
-import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
-import { useStoryblok } from "services/storyblok";
-import { getPaths, getStory } from "utils/apiHelpers";
+import {
+  GetStaticPathsContext,
+  GetStaticPropsContext,
+  InferGetStaticPropsType,
+} from "next";
+import Storyblok, { useStoryblok } from "services/storyblok";
+import { getStoriesPaths, getStory } from "utils/apiHelpers";
 
 export async function getStaticProps(context: GetStaticPropsContext) {
   const {
@@ -25,12 +29,10 @@ export async function getStaticProps(context: GetStaticPropsContext) {
   };
 }
 
-export async function getStaticPaths() {
-  const paths = await getPaths({
-    starts_with: "posts",
-  });
+export async function getStaticPaths({ locales }: GetStaticPathsContext) {
+  const paths = await getStoriesPaths({ starts_with: "posts" }, locales);
   return {
-    paths: paths,
+    paths,
     fallback: "blocking",
   };
 }
@@ -38,7 +40,7 @@ export async function getStaticPaths() {
 export default function PostPage(
   props: InferGetStaticPropsType<typeof getStaticProps>
 ) {
-  const story = useStoryblok(props.story, props.preview, props.locale);
+  const story = useStoryblok(props.story);
   return (
     <Container maxW="100%">
       <Container m="auto" maxW="72rem">

--- a/src/pages/posts/[...slug].tsx
+++ b/src/pages/posts/[...slug].tsx
@@ -1,0 +1,54 @@
+import { Box, Container, Heading } from "@chakra-ui/react";
+import RenderRichText from "components/RenderRichText";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
+import { useStoryblok } from "services/storyblok";
+import { getPaths, getStory } from "utils/apiHelpers";
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+  const {
+    params: { slug },
+  } = context;
+
+  const story = await getStory(`posts/${slug[0]}`, {
+    version: context.preview ? "draft" : "published",
+    language: context.locale,
+    cv: Date.now(),
+  });
+
+  return {
+    props: {
+      story: story,
+      preview: context.preview || false,
+      locale: context.locale,
+    },
+    revalidate: 60 * 60,
+  };
+}
+
+export async function getStaticPaths() {
+  const paths = await getPaths({
+    starts_with: "posts",
+  });
+  return {
+    paths: paths,
+    fallback: "blocking",
+  };
+}
+
+export default function PostPage(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
+  const story = useStoryblok(props.story, props.preview, props.locale);
+  return (
+    <Container maxW="100%">
+      <Container m="auto" maxW="72rem">
+        <Heading as="h1" mb={6} textAlign="center">
+          {story.content.title}
+        </Heading>
+        <Container p={4}>
+          <Box>{RenderRichText(story.content.body)}</Box>
+        </Container>
+      </Container>
+    </Container>
+  );
+}

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -33,7 +33,7 @@ export async function getStaticProps(context: GetStaticPropsContext) {
 export default function PostPage(
   props: InferGetStaticPropsType<typeof getStaticProps>
 ) {
-  const story = useStoryblok(props.story, props.preview, props.locale);
+  const story = useStoryblok(props.story);
 
   return (
     <Container maxW="100%">

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -1,0 +1,59 @@
+import { Box, Container, Heading, VStack } from "@chakra-ui/react";
+import Link from "components/Link";
+import RenderRichText from "components/RenderRichText";
+import { GetStaticPropsContext, InferGetStaticPropsType } from "next";
+import { useStoryblok } from "services/storyblok";
+import { getStories, getStory } from "utils/apiHelpers";
+
+export async function getStaticProps(context: GetStaticPropsContext) {
+  const allStories = await getStories({
+    starts_with: "posts",
+    is_startpage: 0,
+    version: context.preview ? "draft" : "published",
+    language: context.locale,
+    cv: Date.now(),
+  });
+
+  const story = await getStory("posts", {
+    version: context.preview ? "draft" : "published",
+    language: context.locale,
+  });
+
+  return {
+    props: {
+      story: story,
+      stories: allStories,
+      preview: context.preview || false,
+      locale: context.locale,
+    },
+    revalidate: 60 * 60,
+  };
+}
+
+export default function PostPage(
+  props: InferGetStaticPropsType<typeof getStaticProps>
+) {
+  const story = useStoryblok(props.story, props.preview, props.locale);
+
+  return (
+    <Container maxW="100%">
+      <Container m="auto" maxW="72rem">
+        <Heading as="h1" mb={6} textAlign="center">
+          {story.content.title}
+        </Heading>
+        <Container p={4}>
+          <Box>{RenderRichText(story.content.body)}</Box>
+          <VStack>
+            {props.stories.map((story) => {
+              return (
+                <Link key={story.id} href={`/${story.full_slug}`}>
+                  {story.name}
+                </Link>
+              );
+            })}
+          </VStack>
+        </Container>
+      </Container>
+    </Container>
+  );
+}

--- a/src/services/storyblok.ts
+++ b/src/services/storyblok.ts
@@ -28,6 +28,12 @@ export function useStoryblok<T extends StoryData>(
     if (typeof StoryblokBridge !== "undefined") {
       const storyblokInstance = new StoryblokBridge();
 
+      storyblokInstance.pingEditor(() => {
+        if (storyblokInstance.isInEditor()) {
+          console.log("Currently viewing from Editor");
+        }
+      });
+
       // reload on Next.js page on save or publish event in the Visual Editor
       storyblokInstance.on(["change", "published"], () => location.reload());
 
@@ -76,7 +82,13 @@ export function useStoryblok<T extends StoryData>(
 
   useEffect(() => {
     setStory(originalStory); //update the story on locale change inside getServerSideProps
-    if (preview) {
+    // if (preview) {
+    //   addBridge(initEventListeners);
+    // }
+
+    //Storyblok Editors automatically create a bridge inside the Visual Editor
+    if (window.location.search.includes("_storyblok")) {
+      // load the bridge only inside of Storyblok
       addBridge(initEventListeners);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/services/storyblok.ts
+++ b/src/services/storyblok.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import StoryblokClient, { StoryData } from "storyblok-js-client";
+import { useRouter } from "next/router";
 
 declare global {
   interface Window {
@@ -15,12 +16,9 @@ const Storyblok = new StoryblokClient({
   },
 });
 
-export function useStoryblok<T extends StoryData>(
-  originalStory: T,
-  preview: boolean,
-  locale?: string
-) {
+export function useStoryblok<T extends StoryData>(originalStory: T) {
   const [story, setStory] = useState<T>(originalStory);
+  const { locale } = useRouter();
 
   // adds the events for updating the visual editor
   const initEventListeners = () => {
@@ -92,7 +90,7 @@ export function useStoryblok<T extends StoryData>(
       addBridge(initEventListeners);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [originalStory, preview]);
+  }, [originalStory]);
   return story;
 }
 

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -23,6 +23,7 @@ export type StoryblokLinks = {
 export type StoryblokLink = {
   id: number;
   slug: string;
+  name: string;
   is_folder: boolean;
   parent_id: number;
   published: boolean;

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -32,3 +32,8 @@ export type StoryblokLink = {
   is_startpage: boolean;
   real_path: string;
 };
+
+export type LinkParams = {
+  starts_with?: string;
+  version?: "published" | "draft";
+};

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -29,24 +29,31 @@ type LinkPath = {
   };
 };
 
-export async function getPaths(params?: Api.LinkParams) {
+//next thing to do is to prepare all possible slugs with locales
+export async function getStoriesPaths(
+  params?: Api.LinkParams,
+  locales?: string[]
+) {
   const response: GetPathsResult = await Storyblok.get("cdn/links", params);
   const { links } = response.data;
   let paths: LinkPath[] = [];
 
   // get array for slug because of catch all
-  Object.keys(links).forEach((link_id) => {
-    if (!links[link_id].is_startpage) {
-      const slug = links[link_id].slug;
-      const splittedSlug = slug.split("/");
-      const result = {
-        params: {
-          slug: splittedSlug,
-        },
-      };
-      paths.push(result);
-    }
-  });
+  for (const locale of locales) {
+    Object.keys(links).forEach((link_id) => {
+      if (!links[link_id].is_startpage && !links[link_id].is_folder) {
+        const slug = links[link_id].name;
+        const splittedSlug = slug.split("/");
+        const result = {
+          params: {
+            slug: splittedSlug,
+            locale,
+          },
+        };
+        paths.push(result);
+      }
+    });
+  }
 
   return paths;
 }

--- a/src/utils/apiHelpers.ts
+++ b/src/utils/apiHelpers.ts
@@ -1,5 +1,9 @@
 import Storyblok from "services/storyblok";
-import { StoryParams, StoryblokResult } from "storyblok-js-client";
+import {
+  StoryParams,
+  StoriesParams,
+  StoryblokResult,
+} from "storyblok-js-client";
 import * as Api from "types/api";
 
 export async function getStory(
@@ -8,6 +12,11 @@ export async function getStory(
 ): Promise<Api.StoryResult> {
   const response = await Storyblok.getStory(slug, params);
   return response.data.story;
+}
+
+export async function getStories(params?: StoriesParams) {
+  const response = await Storyblok.getStories(params);
+  return response.data.stories;
 }
 
 interface GetPathsResult extends StoryblokResult {
@@ -20,15 +29,14 @@ type LinkPath = {
   };
 };
 
-export async function getPaths() {
-  const response: GetPathsResult = await Storyblok.get("cdn/links");
+export async function getPaths(params?: Api.LinkParams) {
+  const response: GetPathsResult = await Storyblok.get("cdn/links", params);
   const { links } = response.data;
-  console.log("Links", links);
   let paths: LinkPath[] = [];
 
   // get array for slug because of catch all
   Object.keys(links).forEach((link_id) => {
-    if (!links[link_id].is_folder || links[link_id].slug != "home") {
+    if (!links[link_id].is_startpage) {
       const slug = links[link_id].slug;
       const splittedSlug = slug.split("/");
       const result = {
@@ -36,7 +44,6 @@ export async function getPaths() {
           slug: splittedSlug,
         },
       };
-      console.log("result", result);
       paths.push(result);
     }
   });

--- a/src/utils/isDev.ts
+++ b/src/utils/isDev.ts
@@ -1,0 +1,6 @@
+const development: boolean =
+  !process.env.NODE_ENV || process.env.NODE_ENV === "development";
+
+export default function isDev(): boolean {
+  return development;
+}


### PR DESCRIPTION
- using `getStaticPaths` to pre-fetch possible story slugs using `getStoriesPath` API helper function
- Opted for internally build `t` helper function that enables translations for various locales enabled in `next.config.js`
- Approach for enabling preview has changed, preview is enabled for any authenticated editor inside Storyblok CMS, no need to pass back a preview secret to the app to enable the cookie. The bridge will be added when the visual editor appends `_storyblok` to the url params, which only occurs inside the editor.